### PR TITLE
Feat/register user

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,6 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   jsxSingleQuote: true,
-  printWidth: 120,
+  printWidth: 80,
   tabWidth: 2,
 };

--- a/src/components/common/navbar.component.tsx
+++ b/src/components/common/navbar.component.tsx
@@ -29,6 +29,7 @@ const Links = [
   { text: 'Turmas', value: 'classes' },
   { text: 'Alocações', value: 'allocation' },
   { text: 'Prédios', value: 'buildings' },
+  { text: 'Usuários', value: 'users' },
 ];
 
 const NavLink = ({ children, to }: { children: ReactNode; to: string }) => (

--- a/src/components/users/edit.modal.tsx
+++ b/src/components/users/edit.modal.tsx
@@ -22,7 +22,7 @@ import { Building } from 'models/building.model';
 import { useEffect, useState } from 'react';
 import BuildingsService from 'services/buildings.service';
 
-interface RegisterModalProps {
+interface EditModalProps {
   isOpen: boolean;
   onClose: () => void;
   formData?: EditUserFormValues;
@@ -45,7 +45,7 @@ interface BuildingOption {
   label: string;
 }
 
-export default function EditUserModal(props: RegisterModalProps) {
+export default function EditUserModal(props: EditModalProps) {
   const buildingsService = new BuildingsService();
 
   const initialForm: EditUserFormValues = {

--- a/src/components/users/edit.modal.tsx
+++ b/src/components/users/edit.modal.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  Checkbox,
+  Flex,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  NumberInput,
+  NumberInputField,
+} from '@chakra-ui/react';
+import Select from 'react-select';
+import { Building } from 'models/building.model';
+
+import { useEffect, useState } from 'react';
+import BuildingsService from 'services/buildings.service';
+
+interface RegisterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  formData?: EditUserFormValues;
+  otherData?: EditUserOtherData;
+  isUpdate?: boolean;
+  onSave: (data: EditUserFormValues) => void;
+}
+
+interface EditUserFormValues {
+  buildings?: BuildingOption[];
+  isAdmin?: boolean;
+}
+
+interface EditUserOtherData {
+  username?: string;
+  email?: string;
+}
+
+interface BuildingOption {
+  value: string;
+  label: string;
+}
+
+export default function EditUserModal(props: RegisterModalProps) {
+  const buildingsService = new BuildingsService();
+
+  const initialForm: EditUserFormValues = {
+    buildings: [],
+    isAdmin: false,
+  };
+
+  const [isLoadingBuildings, setIsLoadingBuildings] = useState(false);
+  const [buildings, setBuildings] = useState<Building[]>([]);
+  const [form, setForm] = useState<EditUserFormValues>(initialForm);
+
+  useEffect(() => {
+    if (props.formData) setForm(props.formData);
+  }, [props.formData]);
+
+  useEffect(() => {
+    fetchBuildings();
+  }, []);
+
+  async function fetchBuildings() {
+    try {
+      const response = await buildingsService.list();
+      console.log(response.data);
+      setBuildings(response.data);
+      setIsLoadingBuildings(false);
+    } catch (err) {
+      console.error(err);
+      setTimeout(() => {
+        fetchBuildings();
+      }, 1000);
+    }
+  }
+
+  function handleSaveClick() {
+    props.onSave(form);
+    setForm(initialForm);
+    props.onClose();
+  }
+
+  function handleCloseModal() {
+    props.onClose();
+  }
+
+  function isEmpty(value: string) {
+    return value.length <= 0;
+  }
+
+  return (
+    <Modal isOpen={props.isOpen} onClose={handleCloseModal}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{props.isUpdate ? 'Editar informações do prédio' : 'Cadastrar um prédio'}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <Flex direction={'column'} gap={4}>
+            <Flex direction={'column'}>
+              <FormLabel>Username</FormLabel>
+              <Input value={props.otherData?.username} disabled />
+            </Flex>
+            <Flex direction={'column'}>
+              <FormLabel>Email</FormLabel>
+              <Input value={props.otherData?.email} disabled />
+            </Flex>
+            <FormControl>
+              <Checkbox
+                isChecked={form.isAdmin}
+                onChange={(e) => setForm((prev) => ({ ...prev, isAdmin: e.target.checked }))}
+              >
+                Administrador
+              </Checkbox>
+            </FormControl>
+            {!form.isAdmin && (
+              <FormControl>
+                <FormLabel>Prédios</FormLabel>
+                <Select
+                  placeholder={isLoadingBuildings ? 'Carregando...' : 'Selecione um ou mais'}
+                  isLoading={isLoadingBuildings}
+                  isMulti
+                  options={buildings.map((it) => ({ value: it.id, label: it.name }))}
+                  onChange={(selected) => {
+                    const selectedBuildings = selected as BuildingOption[];
+                    setForm((prev) => ({ ...prev, buildings: selectedBuildings }));
+                  }}
+                  value={form.buildings}
+                />
+              </FormControl>
+            )}
+          </Flex>
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme='blue' mr={3} onClick={handleSaveClick}>
+            Salvar
+          </Button>
+          <Button onClick={props.onClose}>Cancelar</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/users/register.modal.tsx
+++ b/src/components/users/register.modal.tsx
@@ -25,19 +25,14 @@ import BuildingsService from 'services/buildings.service';
 interface RegisterModalProps {
   isOpen: boolean;
   onClose: () => void;
-  formData?: EditUserFormValues;
-  otherData?: EditUserOtherData;
-  onSave: (data: EditUserFormValues) => void;
+  onSave: (data: RegisterUserFormValues) => void;
 }
 
-interface EditUserFormValues {
-  buildings?: BuildingOption[];
-  isAdmin?: boolean;
-}
-
-interface EditUserOtherData {
-  username?: string;
-  email?: string;
+export interface RegisterUserFormValues {
+  username: string;
+  email: string;
+  buildings: BuildingOption[];
+  isAdmin: boolean;
 }
 
 interface BuildingOption {
@@ -45,21 +40,19 @@ interface BuildingOption {
   label: string;
 }
 
-export default function EditUserModal(props: RegisterModalProps) {
+export default function RegisterUserModal(props: RegisterModalProps) {
   const buildingsService = new BuildingsService();
 
-  const initialForm: EditUserFormValues = {
+  const initialForm: RegisterUserFormValues = {
+    username: '',
+    email: '',
     buildings: [],
     isAdmin: false,
   };
 
   const [isLoadingBuildings, setIsLoadingBuildings] = useState(false);
   const [buildings, setBuildings] = useState<Building[]>([]);
-  const [form, setForm] = useState<EditUserFormValues>(initialForm);
-
-  useEffect(() => {
-    if (props.formData) setForm(props.formData);
-  }, [props.formData]);
+  const [form, setForm] = useState<RegisterUserFormValues>(initialForm);
 
   useEffect(() => {
     fetchBuildings();
@@ -103,16 +96,30 @@ export default function EditUserModal(props: RegisterModalProps) {
           <Flex direction={'column'} gap={4}>
             <Flex direction={'column'}>
               <FormLabel>Username</FormLabel>
-              <Input value={props.otherData?.username} disabled />
+              <Input
+                placeholder='Username'
+                value={form.username}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, username: event.target.value }))
+                }
+              />
             </Flex>
             <Flex direction={'column'}>
               <FormLabel>Email</FormLabel>
-              <Input value={props.otherData?.email} disabled />
+              <Input
+                placeholder='Email'
+                value={form.email}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, email: event.target.value }))
+                }
+              />
             </Flex>
             <FormControl>
               <Checkbox
                 isChecked={form.isAdmin}
-                onChange={(e) => setForm((prev) => ({ ...prev, isAdmin: e.target.checked }))}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, isAdmin: e.target.checked }))
+                }
               >
                 Administrador
               </Checkbox>
@@ -121,13 +128,23 @@ export default function EditUserModal(props: RegisterModalProps) {
               <FormControl>
                 <FormLabel>Prédios</FormLabel>
                 <Select
-                  placeholder={isLoadingBuildings ? 'Carregando...' : 'Selecione um ou mais'}
+                  placeholder={
+                    isLoadingBuildings
+                      ? 'Carregando...'
+                      : 'Selecione um ou mais'
+                  }
                   isLoading={isLoadingBuildings}
                   isMulti
-                  options={buildings.map((it) => ({ value: it.id, label: it.name }))}
+                  options={buildings.map((it) => ({
+                    value: it.id,
+                    label: it.name,
+                  }))}
                   onChange={(selected) => {
                     const selectedBuildings = selected as BuildingOption[];
-                    setForm((prev) => ({ ...prev, buildings: selectedBuildings }));
+                    setForm((prev) => ({
+                      ...prev,
+                      buildings: selectedBuildings,
+                    }));
                   }}
                   value={form.buildings}
                 />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import AppContextProvider from 'context/AppContext';
 import theme from 'utils/chakra.theme';
 import Buildings from 'pages/buildings';
 import RegisterUser from 'pages/users/registerUser';
+import Users from 'pages/users/users';
 
 Amplify.configure(awsConfig);
 
@@ -29,6 +30,7 @@ root.render(
             <Route path='/index' element={<App />} />
             {/* Private Routes */}
             <Route path='/' element={<AuthRoute />}>
+              <Route path='users' element={<Users />} />
               <Route path='users/register' element={<RegisterUser />} />
               <Route path='buildings' element={<Buildings />} />
               <Route path='classrooms' element={<Classrooms />} />

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -20,3 +20,8 @@ export interface CreateUser {
 export interface CreateUserResponse {
     id: string;
 }
+
+export interface EditUser {
+    building_ids?: Array<string>;
+    isAdmin?: boolean;
+}

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,3 +1,15 @@
+import { Building } from "./building.model";
+
+export interface User {
+    id: string;
+    username: string;
+    isAdmin: boolean;
+    email: string;
+    updated_at: string;
+    created_by?: string;
+    buildings: Array<Building>
+}
+
 export interface CreateUser {
     username: string;
     email: string;

--- a/src/pages/buildings.tsx
+++ b/src/pages/buildings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Auth } from 'aws-amplify';
 import * as C from '@chakra-ui/react';
 import { ColumnDef } from '@tanstack/react-table';
@@ -9,8 +9,10 @@ import RegisterModal from 'components/buildings/register.modal';
 import Dialog from 'components/common/dialog.component';
 import { FaEllipsisV } from 'react-icons/fa';
 import DataTable from 'components/common/dataTable.component';
+import { appContext } from 'context/AppContext';
 
 const Buildings = () => {
+  const { setLoading } = useContext(appContext);
   const buildingsService = new BuildingsService();
 
   const [buildings, setBuildings] = React.useState<Building[]>([]);
@@ -44,6 +46,7 @@ const Buildings = () => {
   ];
 
   useEffect(() => {
+    setLoading(true);
     fetchBuildings();
   }, []);
 
@@ -52,6 +55,7 @@ const Buildings = () => {
       const response = await buildingsService.list();
       console.log(response.data);
       setBuildings(response.data);
+      setLoading(false);
     } catch (err) {
       console.log('err');
       console.error(err);

--- a/src/pages/buildings.tsx
+++ b/src/pages/buildings.tsx
@@ -4,7 +4,11 @@ import * as C from '@chakra-ui/react';
 import { ColumnDef } from '@tanstack/react-table';
 import Navbar from 'components/common/navbar.component';
 import BuildingsService from 'services/buildings.service';
-import { Building, CreateBuilding, UpdateBuilding } from 'models/building.model';
+import {
+  Building,
+  CreateBuilding,
+  UpdateBuilding,
+} from 'models/building.model';
 import RegisterModal from 'components/buildings/register.modal';
 import Dialog from 'components/common/dialog.component';
 import { FaEllipsisV } from 'react-icons/fa';
@@ -16,9 +20,13 @@ const Buildings = () => {
   const buildingsService = new BuildingsService();
 
   const [buildings, setBuildings] = React.useState<Building[]>([]);
-  const [contextBuilding, setContextBuilding] = React.useState<Building | null>(null);
-  const [registerModalOpen, setRegisterModalOpen] = React.useState<boolean>(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false);
+  const [contextBuilding, setContextBuilding] = React.useState<Building | null>(
+    null,
+  );
+  const [registerModalOpen, setRegisterModalOpen] =
+    React.useState<boolean>(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] =
+    React.useState<boolean>(false);
   const [isUpdate, setIsUpdate] = React.useState<boolean>(false);
 
   const columns: ColumnDef<Building>[] = [
@@ -35,10 +43,19 @@ const Buildings = () => {
       meta: { isNumeric: true },
       cell: ({ row }) => (
         <C.Menu>
-          <C.MenuButton as={C.IconButton} aria-label='Options' icon={<C.Icon as={FaEllipsisV} />} variant='ghost' />
+          <C.MenuButton
+            as={C.IconButton}
+            aria-label='Options'
+            icon={<C.Icon as={FaEllipsisV} />}
+            variant='ghost'
+          />
           <C.MenuList>
-            <C.MenuItem onClick={() => handleEditButton(row.original)}>Editar</C.MenuItem>
-            <C.MenuItem onClick={() => handleDeleteButton(row.original)}>Deletar</C.MenuItem>
+            <C.MenuItem onClick={() => handleEditButton(row.original)}>
+              Editar
+            </C.MenuItem>
+            <C.MenuItem onClick={() => handleDeleteButton(row.original)}>
+              Deletar
+            </C.MenuItem>
           </C.MenuList>
         </C.Menu>
       ),
@@ -67,28 +84,37 @@ const Buildings = () => {
 
   async function createBuilding(data: CreateBuilding) {
     try {
+      setLoading(true);
       const response = await buildingsService.create(data);
       fetchBuildings();
     } catch (err) {
       console.error(err);
+      alert('Erro ao criar prédio');
+      setLoading(false);
     }
   }
 
   async function editBuilding(id: string, data: CreateBuilding) {
     try {
-      const _ = await buildingsService.update(id, data);
+      setLoading(true);
+      await buildingsService.update(id, data);
       fetchBuildings();
     } catch (err) {
       console.error(err);
+      alert('Erro ao editar prédio');
+      setLoading(false);
     }
   }
 
   async function deleteBuilding(id: string) {
     try {
-      const _ = await buildingsService.delete(id);
+      setLoading(true);
+      await buildingsService.delete(id);
       fetchBuildings();
     } catch (err) {
       console.error(err);
+      alert('Erro ao deletar prédio');
+      setLoading(false);
     }
   }
 
@@ -147,7 +173,7 @@ const Buildings = () => {
           deleteBuilding(contextBuilding?.id as string);
           setDeleteDialogOpen(false);
         }}
-        title={'Deseja deletar o prédio?'}
+        title={`Deletar o prédio ${contextBuilding?.name}`}
       />
     </>
   );

--- a/src/pages/buildings.tsx
+++ b/src/pages/buildings.tsx
@@ -59,6 +59,9 @@ const Buildings = () => {
     } catch (err) {
       console.log('err');
       console.error(err);
+      setTimeout(() => {
+        fetchBuildings();
+      }, 1000);
     }
   }
 

--- a/src/pages/users/registerUser.tsx
+++ b/src/pages/users/registerUser.tsx
@@ -6,9 +6,6 @@ import { Building } from 'models/building.model';
 import BuildingsService from 'services/buildings.service';
 import UsersService from 'services/users.service';
 
-const buildingsService = new BuildingsService();
-const usersService = new UsersService();
-
 interface RegisterUserFormValues {
   username: string;
   email: string;
@@ -29,6 +26,9 @@ const initialForm: RegisterUserFormValues = {
 };
 
 const RegisterUser = () => {
+  const buildingsService = new BuildingsService();
+  const usersService = new UsersService();
+
   const [form, setForm] = useState(initialForm);
   const [buildings, setBuildings] = useState<Building[]>([]);
   const [isLoadingRegister, setIsLoadingRegister] = useState(false);

--- a/src/pages/users/users.tsx
+++ b/src/pages/users/users.tsx
@@ -9,6 +9,7 @@ import { FilterBoolean } from 'utils/tanstackTableHelpers/tableFiltersFns';
 import { appContext } from 'context/AppContext';
 import { FaEllipsisV } from 'react-icons/fa';
 import EditUserModal from 'components/users/edit.modal';
+import Dialog from 'components/common/dialog.component';
 
 const Users = () => {
   const { setLoading } = useContext(appContext);
@@ -17,6 +18,7 @@ const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [contextUser, setContextUser] = useState<User | null>(null);
   const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
 
   const columns: ColumnDef<User>[] = [
     {
@@ -64,6 +66,9 @@ const Users = () => {
             <C.MenuItem onClick={() => handleEditButton(row.original)}>
               Editar
             </C.MenuItem>
+            <C.MenuItem onClick={() => handleDeleteButton(row.original)}>
+              Deletar
+            </C.MenuItem>
           </C.MenuList>
         </C.Menu>
       ),
@@ -94,6 +99,11 @@ const Users = () => {
     setEditModalOpen(true);
   }
 
+  function handleDeleteButton(user: User) {
+    setDeleteDialogOpen(true);
+    setContextUser(user);
+  }
+
   async function editUser(data: EditUser, user_id: string) {
     setLoading(true);
     try {
@@ -102,6 +112,18 @@ const Users = () => {
     } catch (err: any) {
       console.error(err);
       alert(`Erro ao editar usuário:\n${err.response.data.message}`);
+      setLoading(false);
+    }
+  }
+
+  async function deleteUser(user_id: string) {
+    setLoading(true);
+    try {
+      await usersService.delete(user_id);
+      fetchUsers();
+    } catch (err: any) {
+      console.error(err);
+      alert(`Erro ao deletar usuário:\n${err.response.data.message}`);
       setLoading(false);
     }
   }
@@ -140,6 +162,17 @@ const Users = () => {
             contextUser!.id,
           );
         }}
+      />
+      <Dialog
+        isOpen={deleteDialogOpen}
+        onClose={() => {
+          setDeleteDialogOpen(false);
+        }}
+        onConfirm={() => {
+          deleteUser(contextUser!.id);
+          setDeleteDialogOpen(false);
+        }}
+        title={`Deseja deletar o usuário "${contextUser?.username}"`}
       />
     </>
   );

--- a/src/pages/users/users.tsx
+++ b/src/pages/users/users.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect } from 'react';
+import * as C from '@chakra-ui/react';
+import { ColumnDef } from '@tanstack/react-table';
+import Navbar from 'components/common/navbar.component';
+import UsersService from 'services/users.service';
+import { User, CreateUser } from 'models/user.model';
+import DataTable from 'components/common/dataTable.component';
+import { FilterBoolean } from 'utils/tanstackTableHelpers/tableFiltersFns';
+
+const Users = () => {
+  const usersService = new UsersService();
+
+  const [users, setUsers] = React.useState<User[]>([]);
+
+  const columns: ColumnDef<User>[] = [
+    {
+      accessorKey: 'id',
+      header: 'ID',
+    },
+    {
+      accessorKey: 'username',
+      header: 'Username',
+    },
+    {
+      accessorKey: 'email',
+      header: 'Email',
+    },
+    {
+      accessorKey: 'isAdmin',
+      header: 'Admin',
+      meta: { isBoolean: true },
+      filterFn: FilterBoolean,
+    },
+    {
+      accessorKey: 'updated_at',
+      header: 'Atualizado em',
+    },
+    {
+      accessorKey: 'created_by',
+      header: 'Criado por',
+    },
+    {
+      accessorFn: (row) => row.buildings.map((b) => b.name).join(', '),
+      header: 'Prédios',
+    },
+    {
+      id: 'options',
+      meta: { isNumeric: true },
+    },
+  ];
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  async function fetchUsers() {
+    try {
+      const response = await usersService.list();
+      console.log(response.data);
+      setUsers(response.data);
+    } catch (err) {
+      console.log('err');
+      console.error(err);
+    }
+  }
+
+  return (
+    <>
+      <Navbar />
+      <C.Flex paddingX={4} direction={'column'}>
+        <C.Flex justifyContent={'space-between'} alignItems={'center'}>
+          <C.Text fontSize='4xl' mb={4}>
+            Usuários
+          </C.Text>
+        </C.Flex>
+        <DataTable columns={columns} data={users} />
+      </C.Flex>
+    </>
+  );
+};
+
+export default Users;

--- a/src/pages/users/users.tsx
+++ b/src/pages/users/users.tsx
@@ -10,6 +10,10 @@ import { appContext } from 'context/AppContext';
 import { FaEllipsisV } from 'react-icons/fa';
 import EditUserModal from 'components/users/edit.modal';
 import Dialog from 'components/common/dialog.component';
+import RegisterUser from './registerUser';
+import RegisterUserModal, {
+  RegisterUserFormValues,
+} from 'components/users/register.modal';
 
 const Users = () => {
   const { setLoading } = useContext(appContext);
@@ -18,6 +22,7 @@ const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [contextUser, setContextUser] = useState<User | null>(null);
   const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
+  const [registerModalOpen, setRegisterModalOpen] = useState<boolean>(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
 
   const columns: ColumnDef<User>[] = [
@@ -94,6 +99,10 @@ const Users = () => {
     }
   }
 
+  function handleCreateButton() {
+    setRegisterModalOpen(true);
+  }
+
   function handleEditButton(user: User) {
     setContextUser(user);
     setEditModalOpen(true);
@@ -102,6 +111,25 @@ const Users = () => {
   function handleDeleteButton(user: User) {
     setDeleteDialogOpen(true);
     setContextUser(user);
+  }
+
+  async function registerUser(form: RegisterUserFormValues) {
+    try {
+      setLoading(true);
+      const response = await usersService.create({
+        email: form.email,
+        username: form.username,
+        isAdmin: form.isAdmin,
+        building_ids: form.isAdmin
+          ? undefined
+          : form.buildings.map((it) => it.value),
+      });
+      fetchUsers();
+    } catch (err) {
+      alert('Erro ao cadastrar usuário!');
+      console.error(err);
+      setLoading(false);
+    }
   }
 
   async function editUser(data: EditUser, user_id: string) {
@@ -136,6 +164,7 @@ const Users = () => {
           <C.Text fontSize='4xl' mb={4}>
             Usuários
           </C.Text>
+          <C.Button onClick={handleCreateButton}>Cadastrar</C.Button>
         </C.Flex>
         <DataTable columns={columns} data={users} />
       </C.Flex>
@@ -161,6 +190,13 @@ const Users = () => {
             },
             contextUser!.id,
           );
+        }}
+      />
+      <RegisterUserModal
+        isOpen={registerModalOpen}
+        onClose={() => setRegisterModalOpen(false)}
+        onSave={(form) => {
+          registerUser(form);
         }}
       />
       <Dialog

--- a/src/pages/users/users.tsx
+++ b/src/pages/users/users.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import * as C from '@chakra-ui/react';
 import { ColumnDef } from '@tanstack/react-table';
 import Navbar from 'components/common/navbar.component';
@@ -6,8 +6,10 @@ import UsersService from 'services/users.service';
 import { User, CreateUser } from 'models/user.model';
 import DataTable from 'components/common/dataTable.component';
 import { FilterBoolean } from 'utils/tanstackTableHelpers/tableFiltersFns';
+import { appContext } from 'context/AppContext';
 
 const Users = () => {
+  const { setLoading } = useContext(appContext);
   const usersService = new UsersService();
 
   const [users, setUsers] = React.useState<User[]>([]);
@@ -50,6 +52,7 @@ const Users = () => {
   ];
 
   useEffect(() => {
+    setLoading(true);
     fetchUsers();
   }, []);
 
@@ -58,9 +61,12 @@ const Users = () => {
       const response = await usersService.list();
       console.log(response.data);
       setUsers(response.data);
+      setLoading(false);
     } catch (err) {
-      console.log('err');
       console.error(err);
+      setTimeout(() => {
+        fetchUsers();
+      }, 1000);
     }
   }
 

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -20,4 +20,8 @@ export default class UsersService extends HttpService {
   async update(data: EditUser, user_id: string): Promise<AxiosResponse<Number>> {
     return this.http.put(`/${user_id}`, data);
   }
+
+  async delete(user_id: string): Promise<AxiosResponse<any>> {
+    return this.http.delete(`/${user_id}`);
+  }
 }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,4 +1,4 @@
-import { CreateUser, CreateUserResponse, User } from 'models/user.model';
+import { CreateUser, CreateUserResponse, EditUser, User } from 'models/user.model';
 import HttpService from './http.service';
 import { AxiosResponse } from 'axios';
 
@@ -15,5 +15,9 @@ export default class UsersService extends HttpService {
 
   list(): Promise<AxiosResponse<Array<User>>> {
     return this.http.get('');
+  }
+
+  async update(data: EditUser, user_id: string): Promise<AxiosResponse<Number>> {
+    return this.http.put(`/${user_id}`, data);
   }
 }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,15 +1,19 @@
-import { CreateUser, CreateUserResponse } from 'models/user.model';
+import { CreateUser, CreateUserResponse, User } from 'models/user.model';
 import HttpService from './http.service';
 import { AxiosResponse } from 'axios';
 
 const USPOLIS_SERVER_URL = process.env.REACT_APP_USPOLIS_API_ENDPOINT;
 
 export default class UsersService extends HttpService {
-    constructor() {
-      super(`${USPOLIS_SERVER_URL}/user`);
-    }
+  constructor() {
+    super(`${USPOLIS_SERVER_URL}/user`);
+  }
 
-    create(data: CreateUser): Promise<AxiosResponse<CreateUserResponse>>{
-        return this.http.post('', data);
-    }
+  create(data: CreateUser): Promise<AxiosResponse<CreateUserResponse>> {
+    return this.http.post('', data);
+  }
+
+  list(): Promise<AxiosResponse<Array<User>>> {
+    return this.http.get('');
+  }
 }


### PR DESCRIPTION
Additions:
- users screen: Create, Update and Delete
- there is a /users/register screen that probably will be soon deleted

Testing:
- Create, Update and Delete users: check the changes on MongoDB and on AWS Cognito: OK
- route: /users
- admin should not be able to remove his admin status or delete itself
- admin users should always have no buildings